### PR TITLE
Add just command runner to mac Brewfile

### DIFF
--- a/mac
+++ b/mac
@@ -129,6 +129,7 @@ brew "pyenv"
 brew "pyenv-virtualenv"
 brew "cookiecutter"
 brew "rustup"
+brew "just"
 
 # Applications
 cask "iterm2" unless File.directory?("/Applications/iTerm.app")


### PR DESCRIPTION
Closes #9

Adds [`just`](https://github.com/casey/just) — a simple command runner — to the mac Brewfile. Easier syntax than make and useful for onboarding/running newer tools.